### PR TITLE
Update cheatsheet

### DIFF
--- a/Week_03/cheatsheets/cheatsheet_tuples_lists.ipynb
+++ b/Week_03/cheatsheets/cheatsheet_tuples_lists.ipynb
@@ -204,7 +204,7 @@
     }
    ],
    "source": [
-    "# lists are immutable\n",
+    "# lists are mutable\n",
     "print(li)\n",
     "li[1] = 2 # this will change the second element's value to 2\n",
     "print(li)"


### PR DESCRIPTION
lists were described as "immutable" when it should be "mutable"